### PR TITLE
add disabling object types into lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ Simple protocol router _/s_
   - to run the launcher (these steps will also build the webui)
     - `cd launcher`
     - `npm run start`
+   
+## CLI Usage
+```
+Usage: showbridge [options]
+
+Simple protocol router /s
+
+Options:
+  -V, --version                       output the version number
+  -c, --config <path>                 location of config file
+  -v, --vars <path>                   location of file containing vars
+  -w, --webui <path>                  location of webui html to serve (default: "./webui/dist/webui")
+  --disable-action <action-type>      action type to disable (default: [])
+  --disable-protocol <protocol-type>  protocol type to disable (default: [])
+  --disable-trigger <trigger-type>    trigger type to disable (default: [])
+  -d, --debug                         turn on debug logging (default: false)
+  -t, --trace                         turn on trace logging (default: false)
+  -h, --help                          display help
+```
 
 ## Config File
 The showbridge router's config is entirely controlled by a JSON config file. This file can be made by hand or edited via the web interface included with the launcher. The router WILL NOT start up with an invalid config file. I do provide some starter/example configs to look at to get a general idea of what one entails. 

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "showbridge-lib",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "showbridge-lib",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "showbridge-lib",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Main library for showbridge protocol router",
   "main": "index.js",
   "type": "module",

--- a/lib/src/actions/action.js
+++ b/lib/src/actions/action.js
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { cloneDeep, has, noop } from 'lodash-es';
-import { TransformTypeClassMap, resolveAllKeys } from '../utils/index.js';
+import { TransformTypeClassMap, disabled, resolveAllKeys } from '../utils/index.js';
 
 /**
  * @memberof module:Actions
@@ -64,7 +64,7 @@ class Action extends EventEmitter {
    * @readonly
    */
   get enabled() {
-    return this.obj.enabled;
+    return this.obj.enabled && !disabled.actions.has(this.type);
   }
 
   /**

--- a/lib/src/router.js
+++ b/lib/src/router.js
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { WebSocket } from 'ws';
 import Config from './config.js';
-import { logger } from './utils/index.js';
+import { disabled, logger } from './utils/index.js';
 
 import {
   CloudProtocol,
@@ -111,7 +111,7 @@ class Router extends EventEmitter {
           this.emit('stopped');
         }
       });
-      this.protocols[protocol].stop();
+      this.stopProtocol(protocol);
     });
 
     // NOTE(jwetzell): if protocols haven't stopped in a resaonable time just stop
@@ -128,13 +128,7 @@ class Router extends EventEmitter {
   reload() {
     Object.keys(this.protocols).forEach((protocol) => {
       try {
-        if (this.config[protocol]) {
-          if (this.config[protocol].params) {
-            this.protocols[protocol].reload(this.config[protocol].params);
-          } else {
-            this.protocols[protocol].reload();
-          }
-        }
+        this.startProtocol(protocol);
       } catch (error) {
         logger.error(`router: problem reloading ${protocol} protocol`);
         logger.error(error);
@@ -235,6 +229,44 @@ class Router extends EventEmitter {
         this.processTrigger(trigger, `${msg.messageType}/triggers/${triggerIndex}`, msg);
       });
     }
+  }
+
+  stopProtocol(type) {
+    if (this.protocols[type]) {
+      this.protocols[type].stop();
+    }
+  }
+
+  startProtocol(type) {
+    if (this.config[type] && !disabled.protocols.has(type)) {
+      if (this.config[type].params) {
+        this.protocols[type].reload(this.config[type].params);
+      } else {
+        this.protocols[type].reload();
+      }
+    }
+  }
+
+  disableAction(type) {
+    disabled.actions.add(type);
+  }
+
+  enableAction(type) {
+    disabled.actions.delete(type);
+  }
+
+  disableProtocol(type) {
+    disabled.protocols.add(type);
+    this.stopProtocol(type);
+  }
+
+  enabledProtocol(type) {
+    disabled.protocols.delete(type);
+    this.startProtocol(type);
+  }
+
+  disableTrigger(type) {
+    disabled.triggers.add(type);
   }
 }
 

--- a/lib/src/triggers/trigger.js
+++ b/lib/src/triggers/trigger.js
@@ -1,5 +1,5 @@
 import { has } from 'lodash-es';
-import { ActionTypeClassMap, TriggerTypeClassMap, resolveAllKeys } from '../utils/index.js';
+import { ActionTypeClassMap, TriggerTypeClassMap, disabled, resolveAllKeys } from '../utils/index.js';
 
 /**
  * @memberof module:Triggers
@@ -62,7 +62,7 @@ class Trigger {
    * @returns {boolean} whether this trigger was well triggered by the msg
    */
   shouldFire(msg) {
-    if (!this.enabled) {
+    if (!this.enabled || disabled.triggers.has(this.type)) {
       return false;
     }
     return this.test(msg);

--- a/lib/src/utils/index.js
+++ b/lib/src/utils/index.js
@@ -161,5 +161,13 @@ export const TransformTypeClassMap = {
   template: TemplateTransform,
 };
 
+export const disabled = {
+  actions: new Set(),
+  protocols: new Set(),
+  triggers: new Set(),
+  // TODO(jwetzell): implement disable for the following
+  transforms: new Set(),
+};
+
 // TODO(jwetzell): sort out logging
 export const logger = pino(pretty());

--- a/main.js
+++ b/main.js
@@ -15,6 +15,24 @@ program.description('Simple protocol router /s');
 program.option('-c, --config <path>', 'location of config file', undefined);
 program.option('-v, --vars <path>', 'location of file containing vars', undefined);
 program.option('-w, --webui <path>', 'location of webui html to serve', path.join(__dirname, 'webui/dist/webui'));
+program.option(
+  '--disable-action <action-type>',
+  'action type to disable',
+  (value, previous) => previous.concat([value]),
+  []
+);
+program.option(
+  '--disable-protocol <protocol-type>',
+  'protocol type to disable',
+  (value, previous) => previous.concat([value]),
+  []
+);
+program.option(
+  '--disable-trigger <trigger-type>',
+  'trigger type to disable',
+  (value, previous) => previous.concat([value]),
+  []
+);
 program.option('-d, --debug', 'turn on debug logging', false);
 program.option('-t, --trace', 'turn on trace logging', false);
 program.parse(process.argv);
@@ -202,6 +220,27 @@ import('showbridge-lib').then(({ Config, Router, Utils }) => {
         break;
     }
   });
+
+  if (options.disableAction.length > 0) {
+    options.disableAction.forEach((type) => {
+      logger.debug(`app: disabling action ${type}`);
+      router.disableAction(type);
+    });
+  }
+
+  if (options.disableProtocol.length > 0) {
+    options.disableProtocol.forEach((type) => {
+      logger.debug(`app: disabling protocol ${type}`);
+      router.disableProtocol(type);
+    });
+  }
+
+  if (options.disableTrigger.length > 0) {
+    options.disableTrigger.forEach((type) => {
+      logger.debug(`app: disabling trigger ${type}`);
+      router.disableTrigger(type);
+    });
+  }
 
   router.start();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "showbridge",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "showbridge",
-      "version": "0.3.10",
+      "version": "0.4.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "commander": "^11.0.0",
-        "showbridge-lib": "0.3.3"
+        "showbridge-lib": "0.4.0"
       },
       "bin": {
         "showbridge": "main.js"
@@ -4070,9 +4070,9 @@
       }
     },
     "node_modules/showbridge-lib": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/showbridge-lib/-/showbridge-lib-0.3.3.tgz",
-      "integrity": "sha512-jEgqtfjRqyllU01/RM5nIZXZN/U/MCfzzTBeIX1T4CBJrEIC39zZEUe/bh8R8PVZV6xQ8WQod/71xetaBDhELA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/showbridge-lib/-/showbridge-lib-0.4.0.tgz",
+      "integrity": "sha512-wSZnXsuuhYQ5t/Sf+cQOD5D2zXyAN+4U+83NvnGaVgrO4DkA2VclCZZ8imRS0P0IcamkXeSl8KEVqhDnC9iE4A==",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
         "@julusian/midi": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "showbridge",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "description": "Simple Protocol Router /s",
   "bin": "main.js",
   "files": [
@@ -33,7 +33,7 @@
   "license": "GPL-3.0-only",
   "dependencies": {
     "commander": "^11.0.0",
-    "showbridge-lib": "0.3.3"
+    "showbridge-lib": "0.4.0"
   },
   "devDependencies": {
     "eslint": "^8.51.0",


### PR DESCRIPTION
- disabling of protocols, triggers, and action by their type (i.e. 'http', 'regex', 'shell')
- currently only exposed to the CLI (no ability to disable via webui or launcher or API