### PR TITLE
launcher start/stop cleanup

### DIFF
--- a/launcher/package-lock.json
+++ b/launcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@showbridge/launcher",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@showbridge/launcher",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "@showbridge/cli": "0.4.15",

--- a/launcher/package.json
+++ b/launcher/package.json
@@ -68,6 +68,10 @@
           ]
         }
       ],
+      "extendInfo": {
+        "LSBackgroundOnly": 1,
+        "LSUIElement": 1
+      },
       "hardenedRuntime": true,
       "notarize": {
         "teamId": "JHA7H7P56J"

--- a/launcher/src/main.js
+++ b/launcher/src/main.js
@@ -560,6 +560,7 @@ if (!lock) {
 
 app.on('will-quit', () => {
   console.log('app: will quit');
+  shutdown();
 });
 
 app.on('window-all-closed', () => {

--- a/launcher/src/main.js
+++ b/launcher/src/main.js
@@ -573,3 +573,9 @@ app.on('activate', () => {
     createMainWindow();
   }
 });
+
+app.on('second-instance', () => {
+  if (mainWin) {
+    mainWin.show();
+  }
+});


### PR DESCRIPTION
- no dock icon on macOS
- quitting in any manner SHOULD always kill the underlying showbridge process
- starting a second instance will show the main window of the existing instance