### PR TITLE
use resolved params for port in midi-output action

### DIFF
--- a/lib/src/actions/midi-output-action.js
+++ b/lib/src/actions/midi-output-action.js
@@ -15,7 +15,7 @@ class MIDIOutputAction extends Action {
       const midiToSend = MIDIMessage.parseActionParams(resolvedParams);
 
       if (midiToSend !== undefined) {
-        protocols.midi.send(Buffer.from(midiToSend.bytes), this.params.port);
+        protocols.midi.send(Buffer.from(midiToSend.bytes), resolvedParams.port);
       }
     } catch (error) {
       logger.error(`action: problem executing midi-output action - ${error}`);


### PR DESCRIPTION
- this should have done back when templated midi ports was introduced